### PR TITLE
Fix update offset and cursor position calculation

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -21,7 +21,8 @@ export default class RichTextEditor extends Component {
     editorInitializedCallback: PropTypes.func,
     customCSS: PropTypes.string,
     hiddenTitle: PropTypes.bool,
-    enableOnChange: PropTypes.bool
+    enableOnChange: PropTypes.bool,
+    footerHeight: PropTypes.number
   };
 
   constructor(props) {
@@ -504,10 +505,17 @@ export default class RichTextEditor extends Component {
   init() {
     this._sendAction(actions.init);
     this.setPlatform();
+    if (this.props.footerHeight) {
+      this.setFooterHeight();
+    }
   }
 
   setEditorHeight(height) {
     this._sendAction(actions.setEditorHeight, height);
+  }
+
+  setFooterHeight() {
+    this._sendAction(actions.setFooterHeight, this.props.footerHeight);
   }
 
   setPlatform() {

--- a/src/WebviewMessageHandler.js
+++ b/src/WebviewMessageHandler.js
@@ -164,6 +164,9 @@ export const InjectedMessageHandler = `
         case '${actions.setEditorHeight}':
           zss_editor.setEditorHeight(action.data);
           break;
+        case '${actions.setFooterHeight}':
+          zss_editor.setFooterHeight(action.data);
+          break;
         case '${actions.setPlatform}':
           zss_editor.setPlatform(action.data);
           break;

--- a/src/WebviewMessageHandler.js
+++ b/src/WebviewMessageHandler.js
@@ -161,6 +161,12 @@ export const InjectedMessageHandler = `
         case '${actions.init}':
           zss_editor.init();
           break;
+        case '${actions.setEditorHeight}':
+          zss_editor.setEditorHeight(action.data);
+          break;
+        case '${actions.setPlatform}':
+          zss_editor.setPlatform(action.data);
+          break;
       }
     };
   }

--- a/src/const.js
+++ b/src/const.js
@@ -51,6 +51,7 @@ export const actions = {
   setBackgroundColor: 'SET_BACKGROUND_COLOR',
   init: 'ZSSS_INIT',
   setEditorHeight: 'SET_EDITOR_HEIGHT',
+  setFooterHeight: 'SET_FOOTER_HEIGHT',
   setPlatform: 'SET_PLATFORM'
 };
 

--- a/src/const.js
+++ b/src/const.js
@@ -49,7 +49,9 @@ export const actions = {
   setCustomCSS: 'SET_CUSTOM_CSS',
   setTextColor: 'SET_TEXT_COLOR',
   setBackgroundColor: 'SET_BACKGROUND_COLOR',
-  init: 'ZSSS_INIT'
+  init: 'ZSSS_INIT',
+  setEditorHeight: 'SET_EDITOR_HEIGHT',
+  setPlatform: 'SET_PLATFORM'
 };
 
 

--- a/src/editor.html
+++ b/src/editor.html
@@ -808,7 +808,7 @@
 			zss_editor.enabledItems = {};
 
 			// Height of content window, will be set by viewController
-			zss_editor.contentHeight = 244;
+			zss_editor.editorHeight = 244;
 
 			// Sets to true when extra footer gap shows and requires to hide
 			zss_editor.updateScrollOffset = false;
@@ -901,6 +901,11 @@
 				$(window).on('touchstart', function(e) {
 					zss_editor.isDragging = false;
 				});
+				$(window).on('scroll', function(e) {
+					if (zss_editor.platform === 'ios') {
+						zss_editor.updateOffset();
+					}
+				});
 
 				setupTouchEndFocus('zss_editor_title');
 				setupTouchEndFocus('zss_editor_content');
@@ -952,9 +957,9 @@
 
 				var offsetY = window.document.body.scrollTop;
 
-				var footer = $('#zss_editor_footer');
+				var footer = document.getElementById('zss_editor_footer');
 
-				var maxOffsetY = footer.offset().top - zss_editor.contentHeight;
+				var maxOffsetY = footer.offsetTop + footer.offsetHeight - zss_editor.editorHeight;
 
 				if (maxOffsetY < 0)
 					maxOffsetY = 0;
@@ -1020,22 +1025,23 @@
 			}
 
 			zss_editor.calculateEditorHeightWithCaretPosition = function() {
-
-				var padding = 50;
-				var c = zss_editor.getCaretYPosition();
-
+				var caretYPosition = zss_editor.getCaretYPosition();
+				var lineHeight = 20;
+				var halfLineHeight = lineHeight/2;
 				var offsetY = window.document.body.scrollTop;
-				var height = zss_editor.contentHeight;
+				var editorHeight = zss_editor.editorHeight;
+				var newPos;
 
-				var newPos = window.pageYOffset;
-
-				if (c < offsetY) {
-					newPos = c;
-				} else if (c > (offsetY + height - padding)) {
-					newPos = c - height + padding - 18;
+				var futureEditorHeight = caretYPosition + lineHeight;
+				if (caretYPosition < offsetY) {
+					newPos = caretYPosition;
+				} else if (futureEditorHeight > editorHeight + offsetY) {
+					newPos = futureEditorHeight - editorHeight + halfLineHeight;
 				}
 
-				window.scrollTo(0, newPos);
+				if (newPos) {
+					window.scrollTo(0, newPos);
+				}
 			}
 
 			zss_editor.backuprange = function(){
@@ -1604,6 +1610,14 @@
 				});
 			}
 
+			zss_editor.setEditorHeight = function(editorHeight) {
+				zss_editor.editorHeight = editorHeight;
+			}
+
+			zss_editor.setPlatform = function(platform) {
+				zss_editor.platform = platform;
+			}
+
 			//end
 		</script>
 
@@ -1695,6 +1709,10 @@
 				-webkit-user-select: none;
 				padding-left: 10px;
 				padding-right: 10px;
+			}
+
+			#zss_editor_footer {
+				height: 10px;
 			}
 		</style>
 

--- a/src/editor.html
+++ b/src/editor.html
@@ -1710,10 +1710,6 @@
 				padding-left: 10px;
 				padding-right: 10px;
 			}
-
-			#zss_editor_footer {
-				height: 10px;
-			}
 		</style>
 
 		<style type="text/css">


### PR DESCRIPTION
Hi, Artal! Could you please review this fix?
It fixes problem with calculation of available edit area height and scroll position. On different platforms you should just start to type symbols on new lines. On iPhone 5, for example, you will see that last few lines are placed under toolbar.
Another thing, that on ios devices when you start scrolling, you are able to move text out the view and see a white gap under the text. Update offset fixes this problem.