### PR TITLE
Fixed issue with editor window snapping upward on iOS when ...

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -89,7 +89,7 @@ export default class RichTextEditor extends Component {
     const {marginTop = 0, marginBottom = 0} = this.props.style;
     const spacing = marginTop + marginBottom + top + bottom;
 
-    const editorAvailableHeight = Dimensions.get('window').height - keyboardHeight - spacing;
+    const editorAvailableHeight = Dimensions.get('window').height - (keyboardHeight * 2) - spacing;
     this.setEditorHeight(editorAvailableHeight);
   }
   


### PR DESCRIPTION
scrolling to the bottom.  See:

#32 https://github.com/wix/react-native-zss-rich-text-editor/issues/32

Without fix: 

![editor_snap_at_bottom_ios](https://user-images.githubusercontent.com/5550094/26949031-a1f31c78-4c55-11e7-8164-61c97268a760.gif)

With fix:

![fix-editor-snap-upward](https://user-images.githubusercontent.com/5550094/27313769-f4db9eee-552c-11e7-804e-6fb1ca8d2b4d.gif)