### PR TITLE
New feautre - link modal and keyboard control

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -23,12 +23,24 @@ export default class RichTextEditor extends Component {
     hiddenTitle: PropTypes.bool,
     enableOnChange: PropTypes.bool,
     footerHeight: PropTypes.number,
-    contentInset: PropTypes.object
+    contentInset: PropTypes.object,
+
+    //customize link modal
+    linkTitleText: PropTypes.string,
+    linkURLText: PropTypes.string,
+    linkCancelText: PropTypes.string,
+    linkInsertText: PropTypes.string,
+    linkUpdateText: PropTypes.string,
   };
 
   static defaultProps = {
     contentInset: {},
-    style: {}
+    style: {},
+    linkTitle: 'Title',
+    linkURL: 'URL',
+    linkCancelText: 'Cancel',
+    linkInsertText: 'Insert',
+    linkUpdateText: 'Update',
   };
 
   constructor(props) {
@@ -69,7 +81,6 @@ export default class RichTextEditor extends Component {
   }
 
   _onKeyboardWillShow(event) {
-    console.log('!!!!', event);
     const newKeyboardHeight = event.endCoordinates.height;
     if (this.state.keyboardHeight === newKeyboardHeight) {
       return;
@@ -92,7 +103,7 @@ export default class RichTextEditor extends Component {
     const editorAvailableHeight = Dimensions.get('window').height - keyboardHeight - spacing;
     this.setEditorHeight(editorAvailableHeight);
   }
-  
+
   onBridgeMessage(str){
     try {
       const message = JSON.parse(str);
@@ -209,7 +220,7 @@ export default class RichTextEditor extends Component {
         >
           <View style={styles.modal}>
             <View style={[styles.innerModal, {marginBottom: PlatformIOS ? this.state.keyboardHeight : 0}]}>
-              <Text style={styles.inputTitle}>Title</Text>
+              <Text style={styles.inputTitle}>{this.props.linkTitle}</Text>
               <View style={styles.inputWrapper}>
                 <TextInput
                     style={styles.input}
@@ -217,7 +228,7 @@ export default class RichTextEditor extends Component {
                     value={this.state.linkTitle}
                 />
               </View>
-              <Text style={[styles.inputTitle ,{marginTop: 10}]}>URL</Text>
+              <Text style={[styles.inputTitle ,{marginTop: 10}]}>{this.props.linkURL}</Text>
               <View style={styles.inputWrapper}>
                 <TextInput
                     style={styles.input}
@@ -257,7 +268,7 @@ export default class RichTextEditor extends Component {
             style={buttonPlatformStyle}
         >
           <Text style={[styles.button, {paddingRight: 10}]}>
-            {this._upperCaseButtonTextIfNeeded('Cancel')}
+            {this._upperCaseButtonTextIfNeeded(this.props.linkCancelText)}
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
@@ -273,7 +284,7 @@ export default class RichTextEditor extends Component {
             style={buttonPlatformStyle}
         >
           <Text style={[styles.button, {opacity: insertUpdateDisabled ? 0.5 : 1}]}>
-            {this._upperCaseButtonTextIfNeeded(this._linkIsNew() ? 'Insert' : 'Update')}
+            {this._upperCaseButtonTextIfNeeded(this._linkIsNew() ? this.props.linkInsertText : this.props.linkUpdateText)}
           </Text>
         </TouchableOpacity>
       </View>
@@ -352,7 +363,7 @@ export default class RichTextEditor extends Component {
       selectionChangeListeners: [...this.state.selectionChangeListeners, listener]
     });
   }
-  
+
   enableOnChange() {
     this._sendAction(actions.enableOnChange);
   }

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -31,6 +31,8 @@ export default class RichTextEditor extends Component {
     linkCancelText: PropTypes.string,
     linkInsertText: PropTypes.string,
     linkUpdateText: PropTypes.string,
+
+    showKeyboadrAtFirst: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -41,6 +43,7 @@ export default class RichTextEditor extends Component {
     linkCancelText: 'Cancel',
     linkInsertText: 'Insert',
     linkUpdateText: 'Update',
+    showKeyboadrAtFirst: true,
   };
 
   constructor(props) {
@@ -307,7 +310,7 @@ export default class RichTextEditor extends Component {
         <WebViewBridge
           {...this.props}
           hideKeyboardAccessoryView={true}
-          keyboardDisplayRequiresUserAction={false}
+          keyboardDisplayRequiresUserAction={!this.props.showKeyboardAtFirst}
           ref={(r) => {this.webviewBridge = r}}
           onBridgeMessage={(message) => this.onBridgeMessage(message)}
           injectedJavaScript={injectScript}

--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -32,14 +32,15 @@ export default class RichTextEditor extends Component {
     linkInsertText: PropTypes.string,
     linkUpdateText: PropTypes.string,
 
+    //keyoard control
     showKeyboadrAtFirst: PropTypes.bool,
   };
 
   static defaultProps = {
     contentInset: {},
     style: {},
-    linkTitle: 'Title',
-    linkURL: 'URL',
+    linkTitleText: 'Title',
+    linkURLText: 'URL',
     linkCancelText: 'Cancel',
     linkInsertText: 'Insert',
     linkUpdateText: 'Update',
@@ -223,7 +224,7 @@ export default class RichTextEditor extends Component {
         >
           <View style={styles.modal}>
             <View style={[styles.innerModal, {marginBottom: PlatformIOS ? this.state.keyboardHeight : 0}]}>
-              <Text style={styles.inputTitle}>{this.props.linkTitle}</Text>
+              <Text style={styles.inputTitle}>{this.props.linkTitleText}</Text>
               <View style={styles.inputWrapper}>
                 <TextInput
                     style={styles.input}
@@ -231,7 +232,7 @@ export default class RichTextEditor extends Component {
                     value={this.state.linkTitle}
                 />
               </View>
-              <Text style={[styles.inputTitle ,{marginTop: 10}]}>{this.props.linkURL}</Text>
+              <Text style={[styles.inputTitle ,{marginTop: 10}]}>{this.props.linkURLText}</Text>
               <View style={styles.inputWrapper}>
                 <TextInput
                     style={styles.input}


### PR DESCRIPTION
Allow customizing texts inside the link modal and a new prop.

- This is useful when we are developing an APP based on i18n, we need to consider each different language. Hope you can accept my request.

- Added new props called `showKeyboardAtFirst` to control whether to show it at the first render, since sometimes people would like to preview their post first and then press an edit button to enter the editing mode.
