### PR TITLE
Allow custom icons to be rendered with a function

### DIFF
--- a/src/RichTextToolbar.js
+++ b/src/RichTextToolbar.js
@@ -99,7 +99,14 @@ export default class RichTextToolbar extends Component {
   }
 
   _defaultRenderAction(action, selected) {
-    const icon = this._getButtonIcon(action);
+    let icon = this._getButtonIcon(action);
+    let renderedIcon = null
+    if (typeof icon === 'number') {
+      renderedIcon = <Image source={icon} style={{tintColor: selected ? this.props.selectedIconTint : this.props.iconTint}}/>
+    } else if (typeof icon === 'function') {
+      renderedIcon = icon()
+    }
+
     return (
       <TouchableOpacity
           key={action}
@@ -109,7 +116,7 @@ export default class RichTextToolbar extends Component {
           ]}
           onPress={() => this._onPress(action)}
       >
-        {icon ? <Image source={icon} style={{tintColor: selected ? this.props.selectedIconTint : this.props.iconTint}}/> : null}
+        {renderedIcon}
       </TouchableOpacity>
     );
   }


### PR DESCRIPTION
lets you do the following for custom icons

```jsx
import Icon from 'react-native-vector-icons/FontAwesome'
import { RichTextToolbar, actions } from 'react-native-zss-rich-text-editor'

<RichTextToolbar
  getEditor={() => this.richtext}
  actions={[
    actions.setBold,
    actions.setItalic,
    actions.setUnderline
  ]}
  iconMap={{
    [actions.setBold]: () => (<Icon name='bold' size={20} color='grey'/>),
    [actions.setItalic]: () => (<Icon name='italic' size={20} color='grey'/>),
    [actions.setUnderline]: () => (<Icon name='underline' size={20} color='grey'/>)
  }}
/>

```