### PR TITLE
componentDidReceiveProps part changed to componentDidReceiveProps

### DIFF
--- a/src/RichTextToolbar.js
+++ b/src/RichTextToolbar.js
@@ -50,7 +50,7 @@ export default class RichTextToolbar extends Component {
     };
   }
 
-  componentDidReceiveProps(newProps) {
+  componentWillReceiveProps(newProps) {
     const actions = newProps.actions ? newProps.actions : defaultActions;
     this.setState({
       actions,


### PR DESCRIPTION
The new React version actually asks to use **componentWillReceiveProps** instead of **componentDidReceiveProps**.

Its not a major change but there is a warning that is being shown. And this change won't affect anything at all either. 