### PR TITLE
Fix RichTextToolbar flex alignment and space usage

### DIFF
--- a/src/RichTextToolbar.js
+++ b/src/RichTextToolbar.js
@@ -105,7 +105,7 @@ export default class RichTextToolbar extends Component {
       <TouchableOpacity
           key={action}
           style={[
-            {height: 50, width: 50, justifyContent: 'center'},
+            {height: 50, width: 50, justifyContent: 'center', alignItems: 'center'},
             selected ? this._getButtonSelectedStyle() : this._getButtonUnselectedStyle()
           ]}
           onPress={() => this._onPress(action)}
@@ -128,7 +128,7 @@ export default class RichTextToolbar extends Component {
       >
         <ListView
             horizontal
-            contentContainerStyle={{flexDirection: 'row'}}
+            contentContainerStyle={{flex: 1, flexDirection: 'row', justifyContent: 'center', alignItems: 'center'}}
             dataSource={this.state.ds}
             renderRow= {(row) => this._renderAction(row.action, row.selected)}
         />


### PR DESCRIPTION
### The content was not centered in the RichTextToolbar button.

| Before | After |
| - | - |
| <img width="335" alt="image" src="https://user-images.githubusercontent.com/7189823/38043728-eeb3a408-3285-11e8-99ed-7cf62ea8b067.png"> | <img width="335" alt="image" src="https://user-images.githubusercontent.com/7189823/38043933-58f1be18-3286-11e8-9d4b-f0f3a7d9caed.png"> |

### RichTextToolbar was sliding under his container

| Before | After |
| - | - |
| ![sliding-2](https://user-images.githubusercontent.com/7189823/38048345-15dd3dd4-3293-11e8-8d39-f8beb99b66af.gif) | ![sliding-1](https://user-images.githubusercontent.com/7189823/38044321-67ac7852-3287-11e8-925e-65a1e33dccf2.gif)|

