### PR TITLE
add hideKeyboardAccessoryView property

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -296,7 +296,7 @@ export default class RichTextEditor extends Component {
       <View style={{flex: 1}}>
         <WebViewBridge
           {...this.props}
-          hideKeyboardAccessoryView={true}
+          hideKeyboardAccessoryView={this.props.hideKeyboardAccessoryView ? this.props.hideKeyboardAccessoryView: true}
           keyboardDisplayRequiresUserAction={false}
           ref={(r) => {this.webviewBridge = r}}
           onBridgeMessage={(message) => this.onBridgeMessage(message)}


### PR DESCRIPTION
Some time we need to show the KeyboardAccessories (up down arrows, "Done" button), so, it could be better to allow changing this property (instead of fixing to true as in actual code).