### PR TITLE
Redefining WebViewBridge props

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -295,9 +295,9 @@ export default class RichTextEditor extends Component {
     return (
       <View style={{flex: 1}}>
         <WebViewBridge
-          {...this.props}
           hideKeyboardAccessoryView={true}
           keyboardDisplayRequiresUserAction={false}
+          {...this.props}
           ref={(r) => {this.webviewBridge = r}}
           onBridgeMessage={(message) => this.onBridgeMessage(message)}
           injectedJavaScript={injectScript}


### PR DESCRIPTION
Changing props position to set "hideKeyboardAccessoryView" and "keyboardDisplayRequiresUserAction" from outside. Now if you don't want to show keyboard in first render, you can pass "keyboardDisplayRequiresUserAction={true}" from outside.