### PR TITLE
ios 无法滚动到底部完善

### DIFF
--- a/src/RichTextEditor.js
+++ b/src/RichTextEditor.js
@@ -87,10 +87,13 @@ export default class RichTextEditor extends Component {
 
   setEditorAvailableHeightBasedOnKeyboardHeight(keyboardHeight) {
     const {top = 0, bottom = 0} = this.props.contentInset;
-    const {marginTop = 0, marginBottom = 0} = this.props.style;
+    const {marginTop = 0, marginBottom = 0, height = undefined} = this.props.style;
     const spacing = marginTop + marginBottom + top + bottom;
 
-    const editorAvailableHeight = Dimensions.get('window').height - keyboardHeight - spacing;
+    let editorAvailableHeight = Dimensions.get('window').height - keyboardHeight - spacing;
+    if (height) {
+	    editorAvailableHeight = height - keyboardHeight - spacing;
+    }
     this.setEditorHeight(editorAvailableHeight);
   }
 

--- a/src/editor.html
+++ b/src/editor.html
@@ -1067,8 +1067,10 @@
 				var selection = window.getSelection();
 				selection.removeAllRanges();
 				var range = document.createRange();
-				range.setStart(zss_editor.currentSelection.startContainer, zss_editor.currentSelection.startOffset);
-				range.setEnd(zss_editor.currentSelection.endContainer, zss_editor.currentSelection.endOffset);
+				if (zss_editor.currentSelection) {
+					range.setStart(zss_editor.currentSelection.startContainer, zss_editor.currentSelection.startOffset);
+					range.setEnd(zss_editor.currentSelection.endContainer, zss_editor.currentSelection.endOffset);
+				}
 				selection.addRange(range);
 			}
 


### PR DESCRIPTION
如果富文本框高度不是全屏的时候，会出现内容无法滚动到底部的情况。
if rich-text-editor's height not equal with window's height, content can't scroll to bottom 