### PR TITLE
Fix issue while scrolling in Android

### DIFF
--- a/src/editor.html
+++ b/src/editor.html
@@ -886,7 +886,11 @@
 
 				$(document).on('selectionchange',function(e){
 					console.log('selectionchange');
-					zss_editor.calculateEditorHeightWithCaretPosition();
+
+					if (!zss_editor.isDragging) {
+						zss_editor.calculateEditorHeightWithCaretPosition();
+					}
+
 					zss_editor.setScrollPosition();
 					zss_editor.enabledEditingItems(e);
 					notifyIfSelectedTextHasChanged();


### PR DESCRIPTION
Currently, it isn't possible to scroll in Android devices, once the editor automatically scrolls back to the cursor position.

It seems that the event `selectionchange` is being triggered during a scroll in Android, what ends up in a call to the function `calculateEditorHeightWithCaretPosition`.

**Versions**

* Android - 7.0
* React Native - 0.57.4