### PR TITLE
listview : disable RemoveClippedSubviews prop

### DIFF
--- a/src/RichTextToolbar.js
+++ b/src/RichTextToolbar.js
@@ -131,6 +131,7 @@ export default class RichTextToolbar extends Component {
             contentContainerStyle={{flexDirection: 'row'}}
             dataSource={this.state.ds}
             renderRow= {(row) => this._renderAction(row.action, row.selected)}
+            removeClippedSubviews={false}
         />
       </View>
     );


### PR DESCRIPTION
[removeClippedSubviews](https://facebook.github.io/react-native/docs/view#removeclippedsubviews) was enabled by default.
It's useful for huge lists, with a lot of hidden items (not relevant in this library).

In some situations, with this option the list items are hidden until we scroll on them:
- https://github.com/facebook/react-native/issues/13316
- https://stackoverflow.com/questions/44022857/listview-not-displayed-unless-i-scroll-on-it
- https://github.com/facebook/react-native/issues/1831